### PR TITLE
Update wiki.less

### DIFF
--- a/assets/wiki.less
+++ b/assets/wiki.less
@@ -23,9 +23,7 @@
   }
 
   .wiki-bg {
-    background-image: url('wiki-bg.jpg');
-    background-repeat: no-repeat;
-    background-position: left bottom;
+    background: white url('wiki-bg.jpg') no-repeat left bottom;
   }
 
   .wiki-content {


### PR DESCRIPTION
Some themes may use gradients or other advanced CSS on the `.panel` frame, which in the case of background image on the `.wiki-bg` will break that.

<img src="http://i.imgur.com/C0hx7A8.png" />

Result with fix: 

<img src="http://i.imgur.com/sMdUGn6.png" />

And can later be themed via wiki module/theme