### PR TITLE
Fixed "Pages without category" issue

### DIFF
--- a/Markdown.php
+++ b/Markdown.php
@@ -25,8 +25,10 @@ class Markdown extends \humhub\libs\Markdown
                 return $url;
             }
 
-            if (substr($url, 0, 10) !== "file-guid-" && substr($url, 0, 1) !== "." && substr($url, 0, 1) !== "/" && substr($url, 0, 7) !== "http://" && substr($url, 0, 8) !== "https://") {
-                return Yii::$app->controller->contentContainer->createUrl('/wiki/page/view', array('title' => $url));
+            if (substr($url, 0, 10) !== 'file-guid-' && substr($url, 0, 1) !== '.' && substr($url, 0, 1) !== '/' && 
+            		substr($url, 0, 7) !== 'http://' && substr($url, 0, 8) !== 'https://' &&
+            		substr($url, 0, 7) !== 'mailto:') {
+                  return Yii::$app->controller->contentContainer->createUrl('/wiki/page/view', array('title' => $url));
             }
         }
 

--- a/controllers/OverviewController.php
+++ b/controllers/OverviewController.php
@@ -89,7 +89,9 @@ class OverviewController extends BaseController
             'homePage' => $this->getHomePage(),
             'contentContainer' => $this->contentContainer,
             'categoryPageLimit' => 5,
-            'pagesWithoutCategoryQuery' => WikiPage::find()->contentContainer($this->contentContainer)->andWhere(['IS', 'parent_page_id', new Expression('NULL')]),
+            'pagesWithoutCategoryQuery' => WikiPage::find()->contentContainer($this->contentContainer)
+            	->andWhere(['IS', 'parent_page_id', new Expression('NULL')])
+            	->andWhere(['wiki_page.is_category' => 0]),
         ));
 
     }

--- a/views/overview/list-categories.php
+++ b/views/overview/list-categories.php
@@ -54,7 +54,7 @@ humhub\modules\wiki\Assets::register($this);
                     <?php endforeach; ?>
 
                     <?php $total = $pagesWithoutCategoryQuery->count(); ?>
-                    <?php if ($total !== 0): ?>
+                    <?php if ($total != 0): ?>
                         <li>
                             <div class="page-category-title" style="margin-bottom:12px">
                                 <?= Html::a('<i class="fa fa-list-ol"></i> ' . Yii::t('WikiModule.base', 'Pages without category') . ' (' . $total . ')', $contentContainer->createUrl('/wiki/page/list', [])); ?>


### PR DESCRIPTION
The overview shows «pages without category» - listing all the category
pages in addition to the actual pages without category. Also fixed bug
where this heading still shows up with zero pages.