### PR TITLE
Enh: Public wikis for isGuest

### DIFF
--- a/controllers/PageController.php
+++ b/controllers/PageController.php
@@ -34,7 +34,7 @@ class PageController extends BaseController
     public function beforeAction($action)
     {
         if (parent::beforeAction($action)) {
-            if ($this->contentContainer instanceof Space && !$this->contentContainer->isMember()) {
+            if ($this->contentContainer instanceof Space && !$this->contentContainer->isMember() && !Yii::$app->user->isGuest) {
                 throw new HttpException(403, Yii::t('WikiModule.base', 'You need to be member of the space "%space_name%" to access this wiki page!', ['%space_name%' => $this->contentContainer->name]));
             }
             return true;


### PR DESCRIPTION
With this p/r, it allows for public wikis to be seen by `isGuest` as well as `isMember` while keeping the wikis where they inherit space view permissions. See #56 for more information.

### Example
- Space1 is private and content is private so wikis aren't shown to `isGuest` but will show to `isMember`
- Space2 is public and content is public so wikis are shown to `isGuest` and `isMember`
- Space3 is public and content is private so wikis shouldn't be shown to `isGuest` but will show to `isMember`